### PR TITLE
Refactor Cypress test: clean selectors and improve comment visibility

### DIFF
--- a/cypress/e2e/main.spec.cy.js
+++ b/cypress/e2e/main.spec.cy.js
@@ -2,11 +2,11 @@ describe('template spec', () => {
   it('passes', () => {
     cy.visit('localhost:5173/')
     cy.get('[data-qa="profile-box"]')
-    cy.get('[data-qa="comment-input"]').first().type('Test 123')
-    cy.get('[data-qa="publish-button"]').first().click()
-    cy.get('[data-qa="comment-text"]').contains('Test 123')
+    cy.get('[data-qa="comment-input"]').eq(0).type('Test Ok')
+    cy.get('[data-qa="publish-button"]').eq(0).click()
+    cy.get('[data-qa="comment-text"]').contains('Test Ok')
     cy.get('[data-qa="comment-text"]').each(($element) => {
-      if ($element.text() === 'Test 123') {
+      if ($element.text() === 'Test Ok') {
         cy.get($element).siblings('header').children('[data-qa="delete-button"]').click()
       }
     })


### PR DESCRIPTION
This PR updates the Cypress automation scenario for the post-comment feature:

- Replaced `.first()` with `.eq(0)` for consistent and readable selectors.
- Changed the first test comment text from 'Test 123' to 'Test Ok' for easier visual confirmation during the test.
- Test workflow: visit profile, verify their appearance, and delete it.

These changes improve readability, maintainability, and make it easier to visually verify test behavior.